### PR TITLE
feat: 행사 모아보기 상세페이지 연결 및 jotai install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.0.0",
         "dotenv": "^16.3.1",
+        "jotai": "^2.4.3",
         "lucide-react": "^0.282.0",
         "next": "latest",
         "react": "latest",
@@ -11201,6 +11202,26 @@
       "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.4.3.tgz",
+      "integrity": "sha512-CSAHX9LqWG5WCrU8OgBoZbBJ+Bo9rQU0mPusEF4e0CZ/SNFgurG26vb3UpgvCSJZgYVcUQNiUBM5q86PA8rstQ==",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/jquery": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "dotenv": "^16.3.1",
+    "jotai": "^2.4.3",
     "lucide-react": "^0.282.0",
     "next": "latest",
     "react": "latest",

--- a/src/app/collect/[idx]/page.tsx
+++ b/src/app/collect/[idx]/page.tsx
@@ -1,0 +1,79 @@
+import Image from 'next/legacy/image';
+import Link from 'next/link';
+
+import CollectAPI from '@/api/collectAPI';
+import Button from '@/components/Button/Button';
+
+const CollectDetail = async ({ params }: { params: { idx: number } }) => {
+  const fetchData = await CollectAPI(1, 300);
+  const parseData = JSON.parse(fetchData);
+  const data = parseData?.culturalEventInfo?.row?.[params.idx];
+
+  const { MAIN_IMG, ORG_NAME, TITLE, DATE, PLACE, USE_TRGT, USE_FEE, RGSTDATE, PROGRAM, ORG_LINK } =
+    data;
+
+  return (
+    <div className='flex flex-col items-center max-w-7xl m-auto'>
+      <h1 className='text-4xl font-bold my-16'>행사 상세정보</h1>
+      <div className='flex bg-gray-100 p-12 w-full mb-20 border border-gray-300'>
+        <div className='mr-12'>
+          <Image
+            src={MAIN_IMG}
+            width={400}
+            height={562}
+            alt={TITLE}
+            layout='fixed'
+            placeholder='blur'
+            blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=='
+          />
+        </div>
+        <div className='flex flex-col w-full'>
+          <div className='flex mb-12 justify-between'>
+            <p className='text-2xl text-gray-900 font-bold w-2/3'>{TITLE}</p>
+            <div>
+              <Button variant='register' shape='square' size='medium' weight='bold'>
+                관심공연
+              </Button>
+              <Link href={ORG_LINK} className='ml-4'>
+                <Button variant='register' shape='square' size='medium' weight='bold'>
+                  홈페이지
+                </Button>
+              </Link>
+            </div>
+          </div>
+          <div className='text-lg flex mb-4'>
+            <p className='w-28'>행사기간</p>
+            {DATE}
+          </div>
+          <div className='w-full h-px bg-gray-300'></div>
+          <div className='text-lg flex my-4'>
+            <p className='w-28'>장소/기관명</p>
+            {PLACE} / {ORG_NAME}
+          </div>
+          <div className='w-full h-px bg-gray-300'></div>
+          <div className='text-lg flex my-4'>
+            <p className='w-28'>이용 대상</p>
+            {USE_TRGT}
+          </div>
+          <div className='w-full h-px bg-gray-300'></div>
+          <div className='text-lg flex my-4'>
+            <p className='w-28'>이용 요금</p>
+            {USE_FEE}
+          </div>
+          <div className='w-full h-px bg-gray-300'></div>
+          <div className='text-lg flex my-4'>
+            <p className='w-28'>신청일</p>
+            {RGSTDATE}
+          </div>
+          <div className='w-full h-px bg-gray-300'></div>
+          <div className='text-lg flex my-4'>
+            <p className='w-28'>상세 정보</p>
+            <span className='w-9/12'>{PROGRAM}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CollectDetail;

--- a/src/app/collect/_components/OneItem/index.tsx
+++ b/src/app/collect/_components/OneItem/index.tsx
@@ -1,21 +1,3 @@
-// import Image from 'next/image';
-
-// import { CulturalEventRow } from '../../page';
-
-// const OneItem = ({ item }: { item: CulturalEventRow }) => {
-//   const { MAIN_IMG, ORG_NAME, TITLE } = item;
-//   return (
-//     <div>
-//       <Image src={MAIN_IMG} width={400} height={562} alt='test' />
-//       <div className='flex flex-col items-center my-4'>
-//         <p className='text-lg text-gray-500'>{ORG_NAME}</p>
-//         <p className='text-xl font-bold text-gray-900 mt-2'>{TITLE}</p>
-//       </div>
-//     </div>
-//   );
-// };
-
-// export default OneItem;
 'use client';
 import Image from 'next/image';
 

--- a/src/app/collect/_components/OneItem/index.tsx
+++ b/src/app/collect/_components/OneItem/index.tsx
@@ -1,12 +1,40 @@
+// import Image from 'next/image';
+
+// import { CulturalEventRow } from '../../page';
+
+// const OneItem = ({ item }: { item: CulturalEventRow }) => {
+//   const { MAIN_IMG, ORG_NAME, TITLE } = item;
+//   return (
+//     <div>
+//       <Image src={MAIN_IMG} width={400} height={562} alt='test' />
+//       <div className='flex flex-col items-center my-4'>
+//         <p className='text-lg text-gray-500'>{ORG_NAME}</p>
+//         <p className='text-xl font-bold text-gray-900 mt-2'>{TITLE}</p>
+//       </div>
+//     </div>
+//   );
+// };
+
+// export default OneItem;
+'use client';
 import Image from 'next/image';
 
+// useState 추가
 import { CulturalEventRow } from '../../page';
 
 const OneItem = ({ item }: { item: CulturalEventRow }) => {
   const { MAIN_IMG, ORG_NAME, TITLE } = item;
+
   return (
     <div>
-      <Image src={MAIN_IMG} width={400} height={562} alt='test' />
+      <Image
+        src={MAIN_IMG}
+        width={400}
+        height={562}
+        alt='test'
+        placeholder='blur'
+        blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=='
+      />
       <div className='flex flex-col items-center my-4'>
         <p className='text-lg text-gray-500'>{ORG_NAME}</p>
         <p className='text-xl font-bold text-gray-900 mt-2'>{TITLE}</p>

--- a/src/app/collect/_components/OneItem/index.tsx
+++ b/src/app/collect/_components/OneItem/index.tsx
@@ -1,18 +1,13 @@
-'use client';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
 import { CulturalEventRow } from '../../page';
 
 const OneItem = ({ item, idx }: { item: CulturalEventRow; idx: number }) => {
   const { MAIN_IMG, ORG_NAME, TITLE } = item;
-  const router = useRouter();
-  const handleItemClick = () => {
-    console.log(idx);
-    router.push(`/collect/${idx}`);
-  };
+  const url = `/collect/${idx}`;
   return (
-    <div onClick={handleItemClick} style={{ cursor: 'pointer' }}>
+    <Link href={url}>
       <Image
         src={MAIN_IMG}
         width={400}
@@ -25,7 +20,7 @@ const OneItem = ({ item, idx }: { item: CulturalEventRow; idx: number }) => {
         <p className='text-lg text-gray-500'>{ORG_NAME}</p>
         <p className='text-xl font-bold text-gray-900 mt-2'>{TITLE}</p>
       </div>
-    </div>
+    </Link>
   );
 };
 

--- a/src/app/collect/_components/OneItem/index.tsx
+++ b/src/app/collect/_components/OneItem/index.tsx
@@ -1,19 +1,23 @@
 'use client';
 import Image from 'next/image';
+import { useRouter } from 'next/navigation';
 
-// useState 추가
 import { CulturalEventRow } from '../../page';
 
-const OneItem = ({ item }: { item: CulturalEventRow }) => {
+const OneItem = ({ item, idx }: { item: CulturalEventRow; idx: number }) => {
   const { MAIN_IMG, ORG_NAME, TITLE } = item;
-
+  const router = useRouter();
+  const handleItemClick = () => {
+    console.log(idx);
+    router.push(`/collect/${idx}`);
+  };
   return (
-    <div>
+    <div onClick={handleItemClick} style={{ cursor: 'pointer' }}>
       <Image
         src={MAIN_IMG}
         width={400}
         height={562}
-        alt='test'
+        alt={TITLE}
         placeholder='blur'
         blurDataURL='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFklEQVR42mN8//HLfwYiAOOoQvoqBABbWyZJf74GZgAAAABJRU5ErkJggg=='
       />

--- a/src/app/collect/_components/Select/index.tsx
+++ b/src/app/collect/_components/Select/index.tsx
@@ -1,5 +1,4 @@
-'use client';
-import { useState } from 'react';
+import { useAtom } from 'jotai';
 
 import {
   Select,
@@ -8,12 +7,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { selectValueAtom } from '@/types/collect/atom';
 interface FilterSelectProps {
   onValueChange: (value: string) => void;
 }
 
 const FilterSelect: React.FC<FilterSelectProps> = ({ onValueChange }) => {
-  const [selectedValue, setSelectedValue] = useState<string>('');
+  const [selectedValue, setSelectedValue] = useAtom(selectValueAtom);
   const handleSelectChange = (value: string) => {
     setSelectedValue(value); // 선택한 값을 업데이트
     if (onValueChange) {

--- a/src/app/collect/_components/Select/index.tsx
+++ b/src/app/collect/_components/Select/index.tsx
@@ -21,17 +21,32 @@ const FilterSelect: React.FC<FilterSelectProps> = ({ onValueChange }) => {
     }
   };
   return (
-    <Select value={selectedValue} onValueChange={handleSelectChange}>
-      <SelectTrigger className='w-[180px]'>
-        <SelectValue placeholder='전체' />
-      </SelectTrigger>
-      <SelectContent>
-        <SelectItem value='전체'>전체</SelectItem>
-        <SelectItem value='콘서트'>콘서트</SelectItem>
-        <SelectItem value='클래식'>클래식</SelectItem>
-        <SelectItem value='기타'>기타</SelectItem>
-      </SelectContent>
-    </Select>
+    <div className='mb-3 px-4 w-full flex justify-end'>
+      <Select value={selectedValue} onValueChange={handleSelectChange}>
+        <SelectTrigger className='w-[180px]'>
+          <SelectValue placeholder='전체' />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value='전체'>전체</SelectItem>
+          <SelectItem value='교육/체험'>교육/체험</SelectItem>
+          <SelectItem value='국악'>국악</SelectItem>
+          <SelectItem value='독주/독창회'>독주/독창회</SelectItem>
+          <SelectItem value='무용'>무용</SelectItem>
+          <SelectItem value='뮤지컬/오페라'>뮤지컬/오페라</SelectItem>
+          <SelectItem value='연극'>연극</SelectItem>
+          <SelectItem value='영화'>영화</SelectItem>
+          <SelectItem value='전시/미술'>전시/미술</SelectItem>
+          <SelectItem value='콘서트'>콘서트</SelectItem>
+          <SelectItem value='클래식'>클래식</SelectItem>
+          <SelectItem value='축제-문화/예술'>축제-문화/예술</SelectItem>
+          <SelectItem value='축제-시민화합'>축제-시민화합</SelectItem>
+          <SelectItem value='축제-자연/경관'>축제-자연/경관</SelectItem>
+          <SelectItem value='축제-전통/역사'>축제-전통/역사</SelectItem>
+          <SelectItem value='축제-기타'>축제-기타</SelectItem>
+          <SelectItem value='기타'>기타</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
   );
 };
 export default FilterSelect;

--- a/src/app/collect/_components/SkeletonLoader/index.tsx
+++ b/src/app/collect/_components/SkeletonLoader/index.tsx
@@ -2,13 +2,13 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 const SkeletonLoader = () => {
   return (
-    <div className='grid grid-cols-3 gap-4'>
+    <div className='w-full grid grid-cols-3 gap-4'>
       {[1, 2, 3].map((idx) => (
         <div key={idx} className='p-4'>
-          <Skeleton className='w-[400px] h-[562px] rounded-none' />
+          <Skeleton className='w-full h-[562px] rounded-none' />
           <div className='flex flex-col items-center my-4'>
-            <Skeleton className='w-[200px] h-[20px] rounded-full mb-2' />
-            <Skeleton className='w-[400px] h-[20px] rounded-full' />
+            <Skeleton className='w-1/3 h-5 mb-2 rounded-full' />
+            <Skeleton className='w-1/2 h-5 rounded-full' />
           </div>
         </div>
       ))}

--- a/src/app/collect/page.tsx
+++ b/src/app/collect/page.tsx
@@ -27,7 +27,7 @@ const Collect = () => {
   const [selectedValue, setSelectedValue] = useState<string>('');
 
   useEffect(() => {
-    CollectAPI(1, 50)
+    CollectAPI(1, 300)
       .then((dataString) => {
         const parsedData = JSON.parse(dataString);
         setData(parsedData);

--- a/src/app/collect/page.tsx
+++ b/src/app/collect/page.tsx
@@ -50,7 +50,7 @@ const Collect = () => {
             ) // 선택한 값이 없거나 값이 전체이거나 CODENAME과 일치하는 경우에만 필터링
             .map((item, idx) => (
               <div key={idx} className='p-4'>
-                <OneItem item={item} />
+                <OneItem item={item} idx={idx} />
               </div>
             ))}
         </div>

--- a/src/app/collect/page.tsx
+++ b/src/app/collect/page.tsx
@@ -1,7 +1,9 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { atom, useAtom } from 'jotai';
+import { useEffect } from 'react';
 
 import CollectAPI from '@/api/collectAPI';
+import { selectValueAtom } from '@/types/collect/atom';
 
 import OneItem from './_components/OneItem';
 import FilterSelect from './_components/Select';
@@ -21,10 +23,12 @@ interface CulturalEventInfo {
   };
 }
 
+const dataAtom = atom<CulturalEventInfo | null>(null);
+
 const Collect = () => {
   const apiKey = process.env.NEXT_PUBLIC_API_KEY as string;
-  const [data, setData] = useState<CulturalEventInfo | null>(null);
-  const [selectedValue, setSelectedValue] = useState<string>('');
+  const [data, setData] = useAtom(dataAtom);
+  const [selectedValue, setSelectedValue] = useAtom(selectValueAtom);
 
   useEffect(() => {
     CollectAPI(1, 300)
@@ -35,7 +39,7 @@ const Collect = () => {
       .catch((error) => {
         console.error('에러 발생', error);
       });
-  }, [apiKey, selectedValue]);
+  }, [apiKey, selectedValue, setData]);
 
   return (
     <div className='flex flex-col items-center max-w-7xl m-auto'>

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -1,0 +1,5 @@
+const Pagination = () => {
+  return <div></div>;
+};
+
+export default Pagination;

--- a/src/components/footer/footer.tsx
+++ b/src/components/footer/footer.tsx
@@ -1,7 +1,7 @@
 export default function Footer() {
   return (
     <div className='bg-zinc-700 max-h-24 flex items-center justify-center h-screen'>
-      <div className='text-white font-light'>copyright © mobitory all rights reserved.</div>
+      <div className='text-white font-light'>copyright © nuguna-nuri all rights reserved.</div>
     </div>
   );
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -4,39 +4,41 @@ import { cn } from '@/lib/utils';
 
 export function Header({ className, ...props }: React.HTMLAttributes<HTMLElement>) {
   return (
-    <div className='bg-gray-50 max-h-24 flex flex-center justify-center h-screen'>
-      <nav className={cn('w-7/12 flex items-center space-x-12 ', className)} {...props}>
-        <Link
-          href='/'
-          className='font-semibold text-2xl font-medium transition-colors hover:text-primary'
-        >
-          누구나누리
-        </Link>
-        <Link
-          href='/collect'
-          className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
-        >
-          행사 모아보기
-        </Link>
-        <Link
-          href='/'
-          className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
-        >
-          후기
-        </Link>
-        <Link
-          href='/examples/dashboard'
-          className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
-        >
-          문의
-        </Link>
-        <Link
-          href='/examples/dashboard'
-          className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
-        >
-          소식
-        </Link>
-      </nav>
+    <div className='w-full bg-gray-50'>
+      <div className='h-24 flex items-center mx-auto max-w-7xl'>
+        <nav className={cn(' p-4 space-x-12', className)} {...props}>
+          <Link
+            href='/'
+            className='font-semibold text-2xl font-medium transition-colors hover:text-primary'
+          >
+            누구나누리
+          </Link>
+          <Link
+            href='/collect'
+            className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
+          >
+            행사 모아보기
+          </Link>
+          <Link
+            href='/'
+            className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
+          >
+            후기
+          </Link>
+          <Link
+            href='/examples/dashboard'
+            className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
+          >
+            문의
+          </Link>
+          <Link
+            href='/examples/dashboard'
+            className='text-base font-normal font-semibold text-muted-foreground transition-colors hover:text-primary'
+          >
+            소식
+          </Link>
+        </nav>
+      </div>
     </div>
   );
 }

--- a/src/types/collect/atom.ts
+++ b/src/types/collect/atom.ts
@@ -1,0 +1,2 @@
+import { atom } from 'jotai';
+export const selectValueAtom = atom<string>('');


### PR DESCRIPTION
### 구현 내용 및 구현 화면

1. 행사 모아보기 상세페이지 데이터 페칭 및 퍼블리싱 진행하였습니다.
![image](https://github.com/mobi-community/mobi-nuguna-nuri/assets/123865139/1b37a11b-57f9-43fc-9f5d-102e05e322a2)

2. jotai 설치 후 useState 부분 리팩터링 하였습니다.

3. Header 부분 max-width 1280px로 맞추기 위해 tailwind 속성 변경 있습니다.
-> 다른 컴포넌트 및 페이지 작업시 Wrapper, Container 사용하여 1280px 안에서 작업할 수 있게 해주세요! 아래 코드 주석으로 설명 달아 두었습니다.

```
<div className='w-full bg-gray-50'> // Wrapper -> w-full로 꽉 채워줍니다.
      <div className='h-24 flex items-center mx-auto max-w-7xl'> // Container -> max-w-7xl으로 max-width 설정
        <nav className={cn(' p-4 space-x-12', className)} {...props}>
```

5. Footer 텍스트 수정 있습니다.

<br>

### 주요 사항🌟
#### 🤗 jotai 라이브러리 install 하였습니다!!!